### PR TITLE
Use the actual values received from an Apple Pencil

### DIFF
--- a/HandDrawingSwiftMetal.xcodeproj/project.pbxproj
+++ b/HandDrawingSwiftMetal.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		D4C9791E2ADBAA6400BB666D /* CanvasTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C9791D2ADBAA6400BB666D /* CanvasTransformer.swift */; };
 		D4CBCE452BAA936E0053F198 /* TextureLayerViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CBCE442BAA936E0053F198 /* TextureLayerViewPresenter.swift */; };
 		D4CE84102C8B42BF00DEABC5 /* ViewSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CE840F2C8B42BF00DEABC5 /* ViewSize.swift */; };
+		D4CE84142C8B47D200DEABC5 /* TimeIntervalExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CE84132C8B47D200DEABC5 /* TimeIntervalExtensions.swift */; };
 		D4CF05002B9D4CAF00849A2C /* UIButtonExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CF04FF2B9D4CAF00849A2C /* UIButtonExtensions.swift */; };
 		D4E1ECDD2752388C00D4A23D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E1ECDC2752388C00D4A23D /* AppDelegate.swift */; };
 		D4E1ECDF2752388C00D4A23D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E1ECDE2752388C00D4A23D /* SceneDelegate.swift */; };
@@ -204,6 +205,7 @@
 		D4C9791D2ADBAA6400BB666D /* CanvasTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasTransformer.swift; sourceTree = "<group>"; };
 		D4CBCE442BAA936E0053F198 /* TextureLayerViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextureLayerViewPresenter.swift; sourceTree = "<group>"; };
 		D4CE840F2C8B42BF00DEABC5 /* ViewSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewSize.swift; sourceTree = "<group>"; };
+		D4CE84132C8B47D200DEABC5 /* TimeIntervalExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeIntervalExtensions.swift; sourceTree = "<group>"; };
 		D4CF04FF2B9D4CAF00849A2C /* UIButtonExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButtonExtensions.swift; sourceTree = "<group>"; };
 		D4E1ECD92752388C00D4A23D /* HandDrawingSwiftMetal.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HandDrawingSwiftMetal.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4E1ECDC2752388C00D4A23D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -275,6 +277,7 @@
 				D40D977229DAB0AD00A82E6A /* DictionaryExtensions.swift */,
 				D422D9D12AF50AE4004E058B /* FileManagerExtensions.swift */,
 				D440DF722ADA9E7D00A4E425 /* MTLTextureExtensions.swift */,
+				D4CE84132C8B47D200DEABC5 /* TimeIntervalExtensions.swift */,
 				D40D977129DAB0AD00A82E6A /* UIColorExtensions.swift */,
 				D4B65E5E29DD34A000A0542F /* UIImageExtensions.swift */,
 				D41CACE42B9C023900B8C7C5 /* UIViewExtensions.swift */,
@@ -792,6 +795,7 @@
 				D469A8712C56340B00D10575 /* CanvasSmoothGrayscaleCurveIterator.swift in Sources */,
 				D40D976B29DAB09D00A82E6A /* CanvasEraserDrawingTool.swift in Sources */,
 				D4C8EE9E2B255108005947EC /* CanvasViewModel.swift in Sources */,
+				D4CE84142C8B47D200DEABC5 /* TimeIntervalExtensions.swift in Sources */,
 				D4B4AAA22B3FF44100298CFB /* TextureLayer.swift in Sources */,
 				D40D977529DAB0AD00A82E6A /* DictionaryExtensions.swift in Sources */,
 				D4ACE9A62BA85C240077C888 /* NewCanvasDialogPresenter.swift in Sources */,

--- a/HandDrawingSwiftMetal.xcodeproj/project.pbxproj
+++ b/HandDrawingSwiftMetal.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D400A2762C8BEA5100275138 /* CanvasTouchPointDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D400A2752C8BEA5100275138 /* CanvasTouchPointDummy.swift */; };
+		D400A2782C8BEA5E00275138 /* UITouchDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D400A2772C8BEA5E00275138 /* UITouchDummy.swift */; };
+		D400A27C2C8BEA8800275138 /* CanvasPencilScreenTouchPointsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D400A27B2C8BEA8800275138 /* CanvasPencilScreenTouchPointsTests.swift */; };
 		D40CDEFF2B411F450059527E /* TextureLayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40CDEFE2B411F450059527E /* TextureLayerView.swift */; };
 		D40CDF032B411F660059527E /* TextureLayerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40CDF022B411F660059527E /* TextureLayerListView.swift */; };
 		D40CDF072B4128670059527E /* ColorAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D40CDF062B4128670059527E /* ColorAssets.xcassets */; };
@@ -123,6 +126,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		D400A2752C8BEA5100275138 /* CanvasTouchPointDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasTouchPointDummy.swift; sourceTree = "<group>"; };
+		D400A2772C8BEA5E00275138 /* UITouchDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITouchDummy.swift; sourceTree = "<group>"; };
+		D400A27B2C8BEA8800275138 /* CanvasPencilScreenTouchPointsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasPencilScreenTouchPointsTests.swift; sourceTree = "<group>"; };
 		D40CDEFE2B411F450059527E /* TextureLayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextureLayerView.swift; sourceTree = "<group>"; };
 		D40CDF022B411F660059527E /* TextureLayerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextureLayerListView.swift; sourceTree = "<group>"; };
 		D40CDF062B4128670059527E /* ColorAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ColorAssets.xcassets; sourceTree = "<group>"; };
@@ -250,6 +256,39 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		D400A2732C8BEA3000275138 /* Dummies */ = {
+			isa = PBXGroup;
+			children = (
+				D400A2752C8BEA5100275138 /* CanvasTouchPointDummy.swift */,
+				D400A2772C8BEA5E00275138 /* UITouchDummy.swift */,
+			);
+			path = Dummies;
+			sourceTree = "<group>";
+		};
+		D400A2742C8BEA3F00275138 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				D400A2792C8BEA6A00275138 /* CanvasView */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		D400A2792C8BEA6A00275138 /* CanvasView */ = {
+			isa = PBXGroup;
+			children = (
+				D400A27A2C8BEA7200275138 /* Models */,
+			);
+			path = CanvasView;
+			sourceTree = "<group>";
+		};
+		D400A27A2C8BEA7200275138 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				D400A27B2C8BEA8800275138 /* CanvasPencilScreenTouchPointsTests.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		D40D975029DAB00100A82E6A /* CanvasView */ = {
 			isa = PBXGroup;
 			children = (
@@ -558,6 +597,8 @@
 		D4E1ECF22752388E00D4A23D /* HandDrawingSwiftMetalTests */ = {
 			isa = PBXGroup;
 			children = (
+				D400A2732C8BEA3000275138 /* Dummies */,
+				D400A2742C8BEA3F00275138 /* Views */,
 				D4E1ECF32752388E00D4A23D /* HandDrawingSwiftMetalTests.swift */,
 			);
 			path = HandDrawingSwiftMetalTests;
@@ -829,6 +870,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				D4E1ECF42752388E00D4A23D /* HandDrawingSwiftMetalTests.swift in Sources */,
+				D400A27C2C8BEA8800275138 /* CanvasPencilScreenTouchPointsTests.swift in Sources */,
+				D400A2762C8BEA5100275138 /* CanvasTouchPointDummy.swift in Sources */,
+				D400A2782C8BEA5E00275138 /* UITouchDummy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HandDrawingSwiftMetal.xcodeproj/project.pbxproj
+++ b/HandDrawingSwiftMetal.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		D4C8EE9E2B255108005947EC /* CanvasViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C8EE9D2B255108005947EC /* CanvasViewModel.swift */; };
 		D4C9791E2ADBAA6400BB666D /* CanvasTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C9791D2ADBAA6400BB666D /* CanvasTransformer.swift */; };
 		D4CBCE452BAA936E0053F198 /* TextureLayerViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CBCE442BAA936E0053F198 /* TextureLayerViewPresenter.swift */; };
+		D4CE84102C8B42BF00DEABC5 /* ViewSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CE840F2C8B42BF00DEABC5 /* ViewSize.swift */; };
 		D4CF05002B9D4CAF00849A2C /* UIButtonExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CF04FF2B9D4CAF00849A2C /* UIButtonExtensions.swift */; };
 		D4E1ECDD2752388C00D4A23D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E1ECDC2752388C00D4A23D /* AppDelegate.swift */; };
 		D4E1ECDF2752388C00D4A23D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E1ECDE2752388C00D4A23D /* SceneDelegate.swift */; };
@@ -202,6 +203,7 @@
 		D4C8EE9D2B255108005947EC /* CanvasViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasViewModel.swift; sourceTree = "<group>"; };
 		D4C9791D2ADBAA6400BB666D /* CanvasTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasTransformer.swift; sourceTree = "<group>"; };
 		D4CBCE442BAA936E0053F198 /* TextureLayerViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextureLayerViewPresenter.swift; sourceTree = "<group>"; };
+		D4CE840F2C8B42BF00DEABC5 /* ViewSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewSize.swift; sourceTree = "<group>"; };
 		D4CF04FF2B9D4CAF00849A2C /* UIButtonExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButtonExtensions.swift; sourceTree = "<group>"; };
 		D4E1ECD92752388C00D4A23D /* HandDrawingSwiftMetal.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HandDrawingSwiftMetal.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4E1ECDC2752388C00D4A23D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -453,6 +455,7 @@
 				D48A7DD029DAB81800D235B1 /* Toast.swift */,
 				D44D19732BE5DFE80069D4A9 /* ToastModel.swift */,
 				D40CDF0A2B4130A40059527E /* TimeStampFormatter.swift */,
+				D4CE840F2C8B42BF00DEABC5 /* ViewSize.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -797,6 +800,7 @@
 				D481A4352C5E1E6D00279C91 /* CanvasScreenTouchGestureType.swift in Sources */,
 				D40D976029DAB09400A82E6A /* CanvasTouchPoint.swift in Sources */,
 				D4B4AAA02B3FBEA700298CFB /* MTKTextureUtils.swift in Sources */,
+				D4CE84102C8B42BF00DEABC5 /* ViewSize.swift in Sources */,
 				D40CDF032B411F660059527E /* TextureLayerListView.swift in Sources */,
 				D4E1ECDD2752388C00D4A23D /* AppDelegate.swift in Sources */,
 				D40D979329DAB0D700A82E6A /* Calculate.swift in Sources */,

--- a/HandDrawingSwiftMetal/CanvasView/CanvasViewController.swift
+++ b/HandDrawingSwiftMetal/CanvasView/CanvasViewController.swift
@@ -308,13 +308,17 @@ extension CanvasViewController: CanvasFingerInputGestureRecognizerSender {
 
 extension CanvasViewController: CanvasPencilInputGestureRecognizerSender {
 
-    func sendPencilTouches(_ touches: Set<UITouch>, with event: UIEvent?, on view: UIView) {
+    func sendPencilEstimatedTouches(_ touches: Set<UITouch>, with event: UIEvent?, on view: UIView) {
         canvasViewModel.onPencilGestureDetected(
             touches: touches,
             with: event,
             view: view,
             canvasView: contentView.canvasView
         )
+    }
+
+    func sendPencilActualTouches(_ touches: Set<UITouch>, on view: UIView) {
+
     }
 
 }

--- a/HandDrawingSwiftMetal/CanvasView/CanvasViewController.swift
+++ b/HandDrawingSwiftMetal/CanvasView/CanvasViewController.swift
@@ -310,7 +310,7 @@ extension CanvasViewController: CanvasPencilInputGestureRecognizerSender {
 
     func sendPencilEstimatedTouches(_ touches: Set<UITouch>, with event: UIEvent?, on view: UIView) {
         canvasViewModel.onPencilGestureDetected(
-            touches: touches,
+            estimatedTouches: touches,
             with: event,
             view: view,
             canvasView: contentView.canvasView
@@ -318,7 +318,11 @@ extension CanvasViewController: CanvasPencilInputGestureRecognizerSender {
     }
 
     func sendPencilActualTouches(_ touches: Set<UITouch>, on view: UIView) {
-
+        canvasViewModel.onPencilGestureDetected(
+            actualTouches: touches,
+            view: view,
+            canvasView: contentView.canvasView
+        )
     }
 
 }

--- a/HandDrawingSwiftMetal/CanvasView/CanvasViewModel.swift
+++ b/HandDrawingSwiftMetal/CanvasView/CanvasViewModel.swift
@@ -351,34 +351,70 @@ extension CanvasViewModel {
         }
     }
 
-    // Draw lines on the canvas using the data sent from an Apple Pencil.
     func onPencilGestureDetected(
-        touches: Set<UITouch>,
+        estimatedTouches: Set<UITouch>,
         with event: UIEvent?,
         view: UIView,
         canvasView: CanvasViewProtocol
     ) {
+        // Make `grayscaleTextureCurveIterator` and reset the parameters when a touch begins
+        if estimatedTouches.contains(where: {$0.phase == .began}) {
+            grayscaleTextureCurveIterator = CanvasDefaultGrayscaleCurveIterator()
+            pencilScreenTouchPoints.reset()
+        }
+
+        // Append estimated values to the array
+        event?.allTouches?
+            .compactMap { $0.type == .pencil ? $0 : nil }
+            .sorted { $0.timestamp < $1.timestamp }
+            .forEach { touch in
+                event?.coalescedTouches(for: touch)?.forEach { coalescedTouch in
+                    pencilScreenTouchPoints.appendEstimatedValue(
+                        .init(touch: coalescedTouch, view: view)
+                    )
+                }
+            }
+    }
+
+    func onPencilGestureDetected(
+        actualTouches: Set<UITouch>,
+        view: UIView,
+        canvasView: CanvasViewProtocol
+    ) {
+        // Cancel if there is finger input
         if inputDevice.status == .finger {
             cancelFingerInput(canvasView)
         }
+        // Set `inputDevice` to '.pencil'
         let _ = inputDevice.update(.pencil)
 
-        pencilScreenTouchPoints.append(
-            event: event,
-            in: view
-        )
-        if !(grayscaleTextureCurveIterator is CanvasDefaultGrayscaleCurveIterator) {
-            grayscaleTextureCurveIterator = CanvasDefaultGrayscaleCurveIterator()
+        // Combine `actualTouches` with the estimated values to create actual values, and append them to an array
+        let actualTouchArray = Array(actualTouches).sorted { $0.timestamp < $1.timestamp }
+        actualTouchArray.forEach { actualTouch in
+            pencilScreenTouchPoints.appendActualValueWithEstimatedValue(actualTouch)
+        }
+        if pencilScreenTouchPoints.hasActualValueReplacementCompleted {
+            pencilScreenTouchPoints.appendLastEstimatedTouchPointToActualTouchPointArray()
         }
         guard let grayscaleTextureCurveIterator else { return }
 
-        let screenTouchPoints = pencilScreenTouchPoints.estimatedTouchPointArray
-        let latestScreenTouchPoints = screenTouchPoints.elements(after: pencilScreenTouchPoints.latestCanvasTouchPoint) ?? screenTouchPoints
-        pencilScreenTouchPoints.latestCanvasTouchPoint = screenTouchPoints.last
+        guard
+            // Wait to ensure sufficient time has passed since the previous process
+            // as the operation may not work correctly if the time difference is too short.
+            pencilScreenTouchPoints.hasSufficientTimeElapsedSincePreviousProcess(allowedDifferenceInSeconds: 0.03) ||
+            [UITouch.Phase.ended, UITouch.Phase.cancelled].contains(
+                pencilScreenTouchPoints.actualTouchPointArray.currentTouchPhase
+            )
+        else { return }
 
-        let touchPhase = latestScreenTouchPoints.currentTouchPhase
+        // Retrieve the latest touch points necessary for drawing from the array of stored touch points
+        let latestScreenTouchArray = pencilScreenTouchPoints.latestActualTouchPoints
+        pencilScreenTouchPoints.updateLatestActualTouchPoint()
 
-        let grayscaleTexturePoints: [CanvasGrayscaleDotPoint] = latestScreenTouchPoints.map {
+        let touchPhase = latestScreenTouchArray.currentTouchPhase
+
+        // Convert screen scale points to texture scale, and apply the canvas transformation values to the points
+        let latestTextureTouchArray: [CanvasGrayscaleDotPoint] = latestScreenTouchArray.map {
             .init(
                 touchPoint: $0.convertToTextureCoordinatesAndApplyMatrix(
                     matrix: canvasTransformer.matrix,
@@ -391,10 +427,11 @@ extension CanvasViewModel {
         }
 
         grayscaleTextureCurveIterator.appendToIterator(
-            points: grayscaleTexturePoints,
+            points: latestTextureTouchArray,
             touchPhase: touchPhase
         )
 
+        // Retrieve curve points from the iterator and draw them onto the texture of `textureLayers`
         drawPoints(
             grayscaleTexturePoints: grayscaleTextureCurveIterator.makeCurvePoints(
                 atEnd: touchPhase == .ended
@@ -406,15 +443,12 @@ extension CanvasViewModel {
             with: canvasView.commandBuffer
         )
 
+        // Display the textures
         renderTextures(
             textureLayers: textureLayers,
             touchPhase: touchPhase,
             on: canvasView
         )
-
-        if [UITouch.Phase.ended, UITouch.Phase.cancelled].contains(pencilScreenTouchPoints.estimatedTouchPointArray.currentTouchPhase) {
-            initDrawingParameters()
-        }
     }
 
 }

--- a/HandDrawingSwiftMetal/CanvasView/CanvasViewModel.swift
+++ b/HandDrawingSwiftMetal/CanvasView/CanvasViewModel.swift
@@ -474,6 +474,9 @@ extension CanvasViewModel {
         fingerScreenTouchManager.reset()
         canvasTransformer.reset()
         drawingTexture?.clearDrawingTexture()
+
+        grayscaleTextureCurveIterator = nil
+
         canvasView.clearCommandBuffer()
         canvasView.setNeedsDisplay()
     }

--- a/HandDrawingSwiftMetal/CanvasView/CanvasViewModel.swift
+++ b/HandDrawingSwiftMetal/CanvasView/CanvasViewModel.swift
@@ -63,7 +63,8 @@ final class CanvasViewModel {
 
     private let fingerScreenTouchManager = CanvasFingerScreenTouchPoints()
 
-    private let pencilScreenTouchManager = CanvasPencilScreenTouchPoints()
+    /// A manager for handling Apple Pencil input values
+    private let pencilScreenTouchPoints = CanvasPencilScreenTouchPoints()
 
     private let inputDevice = CanvasInputDeviceStatus()
 
@@ -362,7 +363,7 @@ extension CanvasViewModel {
         }
         let _ = inputDevice.update(.pencil)
 
-        pencilScreenTouchManager.append(
+        pencilScreenTouchPoints.append(
             event: event,
             in: view
         )
@@ -371,9 +372,9 @@ extension CanvasViewModel {
         }
         guard let grayscaleTextureCurveIterator else { return }
 
-        let screenTouchPoints = pencilScreenTouchManager.touchArray
-        let latestScreenTouchPoints = screenTouchPoints.elements(after: pencilScreenTouchManager.latestCanvasTouchPoint) ?? screenTouchPoints
-        pencilScreenTouchManager.latestCanvasTouchPoint = screenTouchPoints.last
+        let screenTouchPoints = pencilScreenTouchPoints.touchArray
+        let latestScreenTouchPoints = screenTouchPoints.elements(after: pencilScreenTouchPoints.latestCanvasTouchPoint) ?? screenTouchPoints
+        pencilScreenTouchPoints.latestCanvasTouchPoint = screenTouchPoints.last
 
         let touchPhase = latestScreenTouchPoints.currentTouchPhase
 
@@ -411,7 +412,7 @@ extension CanvasViewModel {
             on: canvasView
         )
 
-        if [UITouch.Phase.ended, UITouch.Phase.cancelled].contains(pencilScreenTouchManager.touchArray.currentTouchPhase) {
+        if [UITouch.Phase.ended, UITouch.Phase.cancelled].contains(pencilScreenTouchPoints.touchArray.currentTouchPhase) {
             initDrawingParameters()
         }
     }
@@ -427,7 +428,7 @@ extension CanvasViewModel {
         canvasTransformer.reset()
 
         fingerScreenTouchManager.reset()
-        pencilScreenTouchManager.reset()
+        pencilScreenTouchPoints.reset()
         grayscaleTextureCurveIterator = nil
     }
 

--- a/HandDrawingSwiftMetal/CanvasView/CanvasViewModel.swift
+++ b/HandDrawingSwiftMetal/CanvasView/CanvasViewModel.swift
@@ -372,7 +372,7 @@ extension CanvasViewModel {
         }
         guard let grayscaleTextureCurveIterator else { return }
 
-        let screenTouchPoints = pencilScreenTouchPoints.touchArray
+        let screenTouchPoints = pencilScreenTouchPoints.estimatedTouchPointArray
         let latestScreenTouchPoints = screenTouchPoints.elements(after: pencilScreenTouchPoints.latestCanvasTouchPoint) ?? screenTouchPoints
         pencilScreenTouchPoints.latestCanvasTouchPoint = screenTouchPoints.last
 
@@ -412,7 +412,7 @@ extension CanvasViewModel {
             on: canvasView
         )
 
-        if [UITouch.Phase.ended, UITouch.Phase.cancelled].contains(pencilScreenTouchPoints.touchArray.currentTouchPhase) {
+        if [UITouch.Phase.ended, UITouch.Phase.cancelled].contains(pencilScreenTouchPoints.estimatedTouchPointArray.currentTouchPhase) {
             initDrawingParameters()
         }
     }

--- a/HandDrawingSwiftMetal/CanvasView/CanvasViewModel.swift
+++ b/HandDrawingSwiftMetal/CanvasView/CanvasViewModel.swift
@@ -449,6 +449,10 @@ extension CanvasViewModel {
             touchPhase: touchPhase,
             on: canvasView
         )
+
+        if [UITouch.Phase.ended, UITouch.Phase.cancelled].contains(touchPhase) {
+            initDrawingParameters()
+        }
     }
 
 }
@@ -540,10 +544,6 @@ extension CanvasViewModel {
             [UITouch.Phase.ended, UITouch.Phase.cancelled].contains(touchPhase),
             renderTarget: renderTarget
         )
-
-        if [UITouch.Phase.ended, UITouch.Phase.cancelled].contains(touchPhase) {
-            initDrawingParameters()
-        }
 
         if requestShowingLayerViewSubject.value && touchPhase == .ended {
             // Makes a thumbnail with a slight delay to allow processing after the Metal command buffer has completed

--- a/HandDrawingSwiftMetal/CanvasView/CanvasViewModel.swift
+++ b/HandDrawingSwiftMetal/CanvasView/CanvasViewModel.swift
@@ -357,6 +357,13 @@ extension CanvasViewModel {
         view: UIView,
         canvasView: CanvasViewProtocol
     ) {
+        // Cancel if there is finger input
+        if inputDevice.status == .finger {
+            cancelFingerInput(canvasView)
+        }
+        // Set `inputDevice` to '.pencil'
+        let _ = inputDevice.update(.pencil)
+
         // Make `grayscaleTextureCurveIterator` and reset the parameters when a touch begins
         if estimatedTouches.contains(where: {$0.phase == .began}) {
             grayscaleTextureCurveIterator = CanvasDefaultGrayscaleCurveIterator()
@@ -381,13 +388,6 @@ extension CanvasViewModel {
         view: UIView,
         canvasView: CanvasViewProtocol
     ) {
-        // Cancel if there is finger input
-        if inputDevice.status == .finger {
-            cancelFingerInput(canvasView)
-        }
-        // Set `inputDevice` to '.pencil'
-        let _ = inputDevice.update(.pencil)
-
         // Combine `actualTouches` with the estimated values to create actual values, and append them to an array
         let actualTouchArray = Array(actualTouches).sorted { $0.timestamp < $1.timestamp }
         actualTouchArray.forEach { actualTouch in

--- a/HandDrawingSwiftMetal/CanvasView/Gestures/CanvasPencilInputGestureRecognizer.swift
+++ b/HandDrawingSwiftMetal/CanvasView/Gestures/CanvasPencilInputGestureRecognizer.swift
@@ -7,13 +7,14 @@
 
 import UIKit
 
-protocol CanvasPencilInputGestureRecognizerSender: AnyObject {
-    func sendPencilTouches(_ touches: Set<UITouch>, with event: UIEvent?, on view: UIView)
+protocol CanvasPencilInputGestureRecognizerSender {
+    func sendPencilEstimatedTouches(_ touches: Set<UITouch>, with event: UIEvent?, on view: UIView)
+    func sendPencilActualTouches(_ touches: Set<UITouch>, on view: UIView)
 }
 
 final class CanvasPencilInputGestureRecognizer: UIGestureRecognizer {
 
-    weak private var gestureDelegate: CanvasPencilInputGestureRecognizerSender?
+    private var gestureDelegate: CanvasPencilInputGestureRecognizerSender?
 
     init(delegate: CanvasPencilInputGestureRecognizerSender) {
         super.init(target: nil, action: nil)
@@ -24,19 +25,25 @@ final class CanvasPencilInputGestureRecognizer: UIGestureRecognizer {
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         guard let view else { return }
-        gestureDelegate?.sendPencilTouches(touches, with: event, on: view)
+        gestureDelegate?.sendPencilEstimatedTouches(touches, with: event, on: view)
     }
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
         guard let view else { return }
-        gestureDelegate?.sendPencilTouches(touches, with: event, on: view)
+        gestureDelegate?.sendPencilEstimatedTouches(touches, with: event, on: view)
     }
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         guard let view else { return }
-        gestureDelegate?.sendPencilTouches(touches, with: event, on: view)
+        gestureDelegate?.sendPencilEstimatedTouches(touches, with: event, on: view)
     }
     override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
         guard let view else { return }
-        gestureDelegate?.sendPencilTouches(touches, with: event, on: view)
+        gestureDelegate?.sendPencilEstimatedTouches(touches, with: event, on: view)
+    }
+
+    /// https://developer.apple.com/documentation/uikit/apple_pencil_interactions/handling_input_from_apple_pencil/
+    override func touchesEstimatedPropertiesUpdated(_ touches: Set<UITouch>) {
+        guard let view else { return }
+        gestureDelegate?.sendPencilActualTouches(touches, on: view)
     }
 
 }

--- a/HandDrawingSwiftMetal/CanvasView/Models/Drawing/Points/CanvasPencilScreenTouchPoints.swift
+++ b/HandDrawingSwiftMetal/CanvasView/Models/Drawing/Points/CanvasPencilScreenTouchPoints.swift
@@ -6,20 +6,130 @@
 //
 
 import UIKit
-
+/// https://developer.apple.com/documentation/uikit/apple_pencil_interactions/handling_input_from_apple_pencil/
+/// Since an Apple Pencil is a separate device from an iPad,
+/// `UIGestureRecognizer` initially sends estimated values and then sends the actual values shortly after.
+///  This class is a model that combines estimated and actual values to create an array of `CanvasTouchPoint`.
+///  It stores the estimated values in `estimatedTouchPointArray` and then combines them with the actual values received later
+///  to create the values for `actualTouchPointArray`.
 final class CanvasPencilScreenTouchPoints {
 
-    private (set) var touchArray: [CanvasTouchPoint] = []
+    /// An array that holds elements combining actualTouches, where the force values are accurate, and estimatedTouchPointArray.
+    private (set) var actualTouchPointArray: [CanvasTouchPoint] = []
+
+    /// An array that holds estimated values where the TouchPhase values are accurate.
+    private (set) var estimatedTouchPointArray: [CanvasTouchPoint] = []
+
+    /// An index of the processed elements in `estimatedTouchPointArray`
+    private (set) var latestEstimatedTouchArrayIndex = 0
+
+    /// An element processed in `actualTouchPointArray`
+    private (set) var latestActualTouchPoint: CanvasTouchPoint? = nil
+
+    private (set) var lastEstimationUpdateIndexAtCompletion: NSNumber? = nil
 
     /// A variable used to get elements from the array starting from the next element after this point
     var latestCanvasTouchPoint: CanvasTouchPoint?
+
+    init(
+        actualTouchPointArray: [CanvasTouchPoint] = [],
+        estimatedTouchPointArray: [CanvasTouchPoint] = [],
+        latestEstimatedTouchArrayIndex: Int = 0,
+        latestActualTouchPoint: CanvasTouchPoint? = nil
+    ) {
+        self.actualTouchPointArray = actualTouchPointArray
+        self.estimatedTouchPointArray = estimatedTouchPointArray
+        self.latestEstimatedTouchArrayIndex = latestEstimatedTouchArrayIndex
+        self.latestActualTouchPoint = latestActualTouchPoint
+    }
+
 }
 
 extension CanvasPencilScreenTouchPoints {
 
-    var isEmpty: Bool {
-        touchArray.isEmpty
+    /// Use the elements of `actualTouchPointArray` after `latestActualTouchPoint` for line drawing
+    var latestActualTouchPoints: [CanvasTouchPoint] {
+        actualTouchPointArray.elements(after: latestActualTouchPoint) ?? actualTouchPointArray
     }
+
+    var hasActualValueReplacementCompleted: Bool {
+        actualTouchPointArray.last?.estimationUpdateIndex == lastEstimationUpdateIndexAtCompletion
+    }
+
+    /// Check if the time difference between the creation of the last element in `actualTouchPointArray` and `latestActualTouchPoint` is within the allowed difference in seconds
+    func hasSufficientTimeElapsedSincePreviousProcess(allowedDifferenceInSeconds seconds: TimeInterval) -> Bool {
+        guard
+            let latestActualTouchPointTimestamp = actualTouchPointArray.last?.timestamp
+        else { return false }
+
+        if let endLineTimestamp = latestActualTouchPoint?.timestamp {
+            return endLineTimestamp.isTimeDifferenceExceeding(latestActualTouchPointTimestamp, allowedDifferenceInSeconds: seconds)
+        } else {
+            return true
+        }
+    }
+
+    func appendEstimatedValue(_ touchPoint: CanvasTouchPoint) {
+        estimatedTouchPointArray.append(touchPoint)
+        updateLastEstimationUpdateIndexAtCompletionForTouchCompletion()
+    }
+
+    /// Combine `actualTouches` with the estimated values to create elements and append them to `actualTouchPointArray`
+    func appendActualValueWithEstimatedValue(_ actualTouch: UITouch) {
+        for i in latestEstimatedTouchArrayIndex ..< estimatedTouchPointArray.count {
+            let estimatedTouchPoint = estimatedTouchPointArray[i]
+
+            // Find the one that matches `estimationUpdateIndex`
+            if actualTouch.estimationUpdateIndex == estimatedTouchPoint.estimationUpdateIndex,
+               ![UITouch.Phase.ended, UITouch.Phase.cancelled].contains(estimatedTouchPoint.phase) {
+
+                actualTouchPointArray.append(
+                    .init(
+                        location: estimatedTouchPoint.location,
+                        phase: estimatedTouchPoint.phase,
+                        force: actualTouch.force,
+                        maximumPossibleForce: actualTouch.maximumPossibleForce,
+                        estimationUpdateIndex: actualTouch.estimationUpdateIndex,
+                        timestamp: actualTouch.timestamp
+                    )
+                )
+
+                latestEstimatedTouchArrayIndex = i
+            }
+        }
+    }
+
+    /// Add an element with `UITouch.Phase.ended` to the end of `actualTouchPointArray`
+    func appendLastEstimatedTouchPointToActualTouchPointArray() {
+        guard let point = estimatedTouchPointArray.last else { return }
+        actualTouchPointArray.append(point)
+    }
+
+    /// After using the array, update `latestActualTouchPoint` with the last element of `actualTouchPointArray` and use it for the next drawing.
+    func updateLatestActualTouchPoint() {
+        latestActualTouchPoint = actualTouchPointArray.last
+    }
+
+    func updateLastEstimationUpdateIndexAtCompletionForTouchCompletion() {
+        // When the touch ends, `estimationUpdateIndex` of `UITouch` becomes nil,
+        // so the `estimationUpdateIndex` of the previous `UITouch` is retained.
+        if [UITouch.Phase.ended, UITouch.Phase.cancelled].contains(estimatedTouchPointArray.last?.phase) {
+            lastEstimationUpdateIndexAtCompletion = estimatedTouchPointArray.dropLast().last?.estimationUpdateIndex
+        }
+    }
+
+    func reset() {
+        actualTouchPointArray = []
+        estimatedTouchPointArray = []
+        latestEstimatedTouchArrayIndex = 0
+        latestActualTouchPoint = nil
+        lastEstimationUpdateIndexAtCompletion = nil
+        latestCanvasTouchPoint = nil
+    }
+
+}
+
+extension CanvasPencilScreenTouchPoints {
 
     func append(event: UIEvent?, in view: UIView) {
         event?.allTouches?.forEach { touch in
@@ -29,16 +139,11 @@ extension CanvasPencilScreenTouchPoints {
             else { return }
 
             coalescedTouches.forEach { coalescedTouch in
-                touchArray.append(
+                estimatedTouchPointArray.append(
                     .init(touch: coalescedTouch, view: view)
                 )
             }
         }
-    }
-
-    func reset() {
-        touchArray = []
-        latestCanvasTouchPoint = nil
     }
 
 }

--- a/HandDrawingSwiftMetal/CanvasView/Models/Drawing/Points/CanvasTouchPoint.swift
+++ b/HandDrawingSwiftMetal/CanvasView/Models/Drawing/Points/CanvasTouchPoint.swift
@@ -10,11 +10,13 @@ import UIKit
 struct CanvasTouchPoint: Equatable {
 
     let location: CGPoint
+    let phase: UITouch.Phase
     let force: CGFloat
     let maximumPossibleForce: CGFloat
-    let phase: UITouch.Phase
-    let type: UITouch.TouchType
+    /// Index for identifying the estimated value
+    var estimationUpdateIndex: NSNumber? = nil
 
+    let timestamp: TimeInterval
 }
 
 extension CanvasTouchPoint {
@@ -24,10 +26,11 @@ extension CanvasTouchPoint {
         view: UIView
     ) {
         self.location = touch.preciseLocation(in: view)
+        self.phase = touch.phase
         self.force = touch.force
         self.maximumPossibleForce = touch.maximumPossibleForce
-        self.phase = touch.phase
-        self.type = touch.type
+        self.estimationUpdateIndex = touch.estimationUpdateIndex
+        self.timestamp = touch.timestamp
     }
 
 }
@@ -82,10 +85,11 @@ extension CanvasTouchPoint {
                 with: inverseMatrix,
                 textureSize: textureSize
             ),
+            phase: phase,
             force: force,
             maximumPossibleForce: maximumPossibleForce,
-            phase: phase,
-            type: type
+            estimationUpdateIndex: estimationUpdateIndex,
+            timestamp: timestamp
         )
     }
 

--- a/HandDrawingSwiftMetal/Extensions/CGPointExtensions.swift
+++ b/HandDrawingSwiftMetal/Extensions/CGPointExtensions.swift
@@ -32,4 +32,18 @@ extension CGPoint {
         return point
     }
 
+    func scale(_ sourceSize: CGSize, to destinationSize: CGSize) -> Self {
+        let scaleFrameToTexture = ViewSize.getScaleToFit(sourceSize, to: destinationSize)
+
+        return .init(
+            x: self.x * scaleFrameToTexture,
+            y: self.y * scaleFrameToTexture
+        )
+    }
+
+    func distance(_ to: CGPoint?) -> CGFloat {
+        guard let value = to else { return 0.0 }
+        return sqrt(pow(value.x - x, 2) + pow(value.y - y, 2))
+    }
+
 }

--- a/HandDrawingSwiftMetal/Extensions/TimeIntervalExtensions.swift
+++ b/HandDrawingSwiftMetal/Extensions/TimeIntervalExtensions.swift
@@ -1,0 +1,16 @@
+//
+//  TimeIntervalExtensions.swift
+//  HandDrawingSwiftMetal
+//
+//  Created by Eisuke Kusachi on 2024/09/06.
+//
+
+import Foundation
+
+extension TimeInterval {
+    /// Checks if the difference between two TimeIntervals exceeds the allowed range
+    func isTimeDifferenceExceeding(_ otherInterval: TimeInterval, allowedDifferenceInSeconds: TimeInterval) -> Bool {
+        abs(self - otherInterval) >= allowedDifferenceInSeconds
+    }
+
+}

--- a/HandDrawingSwiftMetal/Utils/ViewSize.swift
+++ b/HandDrawingSwiftMetal/Utils/ViewSize.swift
@@ -1,0 +1,20 @@
+//
+//  ViewSize.swift
+//  HandDrawingSwiftMetal
+//
+//  Created by Eisuke Kusachi on 2024/09/06.
+//
+
+import Foundation
+
+enum ViewSize {
+
+    static func getScaleToFit(_ source: CGSize, to destination: CGSize) -> CGFloat {
+
+        let ratioWidth = destination.width / source.width
+        let ratioHeight = destination.height / source.height
+
+        return ratioWidth < ratioHeight ? ratioWidth : ratioHeight
+    }
+
+}

--- a/HandDrawingSwiftMetalTests/Dummies/CanvasTouchPointDummy.swift
+++ b/HandDrawingSwiftMetalTests/Dummies/CanvasTouchPointDummy.swift
@@ -1,0 +1,31 @@
+//
+//  CanvasTouchPointDummy.swift
+//  HandDrawingSwiftMetalTests
+//
+//  Created by Eisuke Kusachi on 2024/09/07.
+//
+
+import UIKit
+@testable import HandDrawingSwiftMetal
+
+extension CanvasTouchPoint {
+
+    static func generate(
+        location: CGPoint = .zero,
+        phase: UITouch.Phase = .cancelled,
+        force: CGFloat = 0,
+        maximumPossibleForce: CGFloat = 0,
+        estimationUpdateIndex: NSNumber? = nil,
+        timestamp: TimeInterval = 0
+    ) -> CanvasTouchPoint {
+        .init(
+            location: location,
+            phase: phase,
+            force: force,
+            maximumPossibleForce: maximumPossibleForce,
+            estimationUpdateIndex: estimationUpdateIndex,
+            timestamp: timestamp
+        )
+    }
+
+}

--- a/HandDrawingSwiftMetalTests/Dummies/UITouchDummy.swift
+++ b/HandDrawingSwiftMetalTests/Dummies/UITouchDummy.swift
@@ -1,0 +1,35 @@
+//
+//  UITouchDummy.swift
+//  HandDrawingSwiftMetalTests
+//
+//  Created by Eisuke Kusachi on 2024/09/07.
+//
+
+import UIKit
+
+final class UITouchDummy: UITouch {
+
+    override var phase: UITouch.Phase { _phase }
+    override var force: CGFloat { _force }
+    override var estimationUpdateIndex: NSNumber? { _estimationUpdateIndex }
+    override var timestamp: TimeInterval { _timestamp }
+
+    private let _phase: UITouch.Phase
+    private let _force: CGFloat
+    private let _estimationUpdateIndex: NSNumber?
+    private let _timestamp: TimeInterval
+
+    init(
+        phase: UITouch.Phase = .cancelled,
+        force: CGFloat = 0.0,
+        estimationUpdateIndex: NSNumber? = nil,
+        timestamp: TimeInterval = 0.0
+    ) {
+        self._phase = phase
+        self._force = force
+        self._estimationUpdateIndex = estimationUpdateIndex
+        self._timestamp = timestamp
+        super.init()
+    }
+
+}

--- a/HandDrawingSwiftMetalTests/Views/CanvasView/Models/CanvasPencilScreenTouchPointsTests.swift
+++ b/HandDrawingSwiftMetalTests/Views/CanvasView/Models/CanvasPencilScreenTouchPointsTests.swift
@@ -1,0 +1,173 @@
+//
+//  CanvasPencilScreenTouchPointsTests.swift
+//  HandDrawingSwiftMetalTests
+//
+//  Created by Eisuke Kusachi on 2024/09/07.
+//
+
+import XCTest
+@testable import HandDrawingSwiftMetal
+
+final class CanvasPencilScreenTouchPointsTests: XCTestCase {
+
+    /// Confirms that the replacement with the actual values is complete
+    func testHasActualValueReplacementCompleted() {
+        let estimatedTouchPointArray: [CanvasTouchPoint] = [
+            .generate(phase: .began, estimationUpdateIndex: 0),
+            .generate(phase: .moved, estimationUpdateIndex: 1),
+            .generate(phase: .ended, estimationUpdateIndex: nil)
+        ]
+        let actualTouches: [UITouch] = [
+            UITouchDummy.init(phase: .began, estimationUpdateIndex: 0),
+            UITouchDummy.init(phase: .moved, estimationUpdateIndex: 1)
+        ]
+
+        let subject = CanvasPencilScreenTouchPoints(
+            estimatedTouchPointArray: estimatedTouchPointArray
+        )
+        subject.updateLastEstimationUpdateIndexAtCompletionForTouchCompletion()
+
+        /// Confirms that `lastEstimationUpdateIndexAtCompletion` contains `estimationUpdateIndex` of the second-to-last element of `estimatedTouchPointArray`
+        XCTAssertEqual(subject.lastEstimationUpdateIndexAtCompletion, 1)
+
+        subject.appendActualValueWithEstimatedValue(actualTouches[0])
+        XCTAssertEqual(subject.actualTouchPointArray.last?.estimationUpdateIndex, 0)
+
+        XCTAssertFalse(subject.hasActualValueReplacementCompleted)
+
+        subject.appendActualValueWithEstimatedValue(actualTouches[1])
+        XCTAssertEqual(subject.actualTouchPointArray.last?.estimationUpdateIndex, 1)
+
+        /// Completion is determined when `lastEstimationUpdateIndexAtCompletion` matches `estimationUpdateIndex` of the last element in `actualTouchPointArray`
+        XCTAssertTrue(subject.hasActualValueReplacementCompleted)
+    }
+
+    /// Confirms that the specified amount of time has passed since the last process
+    func testHasSufficientTimeElapsedSincePreviousProcess() {
+        let allowedDifferenceInSeconds: TimeInterval = 2
+
+        let actualTouches: [(UITouch, Bool)] = [
+            /// Returns `true` since `latestActualTouchPoint` is nil, and then updates `latestActualTouchPoint`
+            (UITouchDummy.init(phase: .began, estimationUpdateIndex: 0, timestamp: 2), true),
+
+            /// Returns `false` since the time difference from `latestActualTouchPoint` is within 2 seconds
+            (UITouchDummy.init(phase: .moved, estimationUpdateIndex: 1, timestamp: 3), false),
+
+            /// Returns `true` since the time difference from `latestActualTouchPoint` exceeds 2 seconds, and then updates `latestActualTouchPoint`
+            (UITouchDummy.init(phase: .moved, estimationUpdateIndex: 2, timestamp: 4), true),
+
+            /// Returns `false` since the time difference from `latestActualTouchPoint` is within 2 seconds
+            (UITouchDummy.init(phase: .moved, estimationUpdateIndex: 3, timestamp: 5), false)
+        ]
+
+        let subject = CanvasPencilScreenTouchPoints(
+            estimatedTouchPointArray: [
+                .generate(phase: .began, estimationUpdateIndex: 0),
+                .generate(phase: .moved, estimationUpdateIndex: 1),
+                .generate(phase: .moved, estimationUpdateIndex: 2),
+                .generate(phase: .moved, estimationUpdateIndex: 3)
+            ]
+        )
+
+        actualTouches.forEach { actualTouch in
+            subject.appendActualValueWithEstimatedValue(actualTouch.0)
+
+            let hasSufficientTimeElapsed = subject.hasSufficientTimeElapsedSincePreviousProcess(
+                allowedDifferenceInSeconds: allowedDifferenceInSeconds
+            )
+            XCTAssertEqual(hasSufficientTimeElapsed, actualTouch.1)
+
+            /// Updates `latestActualTouchPoint` if the specified time has elapsed
+            if hasSufficientTimeElapsed {
+                subject.updateLatestActualTouchPoint()
+            }
+        }
+    }
+
+    /// Confirms that elements created by combining actual and estimated values are added to `actualTouchPointArray`
+    func testAppendActualValueWithEstimatedValue() {
+        let estimatedTouches: [CanvasTouchPoint] = [
+            .generate(phase: .began, force: 1.0, estimationUpdateIndex: 0),
+            .generate(phase: .moved, force: 1.0, estimationUpdateIndex: 1),
+            .generate(phase: .moved, force: 1.0, estimationUpdateIndex: 2),
+            .generate(phase: .ended, force: 0.0, estimationUpdateIndex: nil)
+        ]
+
+        let actualTouches: [UITouch] = [
+            UITouchDummy.init(phase: .began, force: 0.3, estimationUpdateIndex: 0),
+            UITouchDummy.init(phase: .moved, force: 0.2, estimationUpdateIndex: 1),
+            UITouchDummy.init(phase: .moved, force: 0.1, estimationUpdateIndex: 2)
+        ]
+
+        let subject = CanvasPencilScreenTouchPoints(
+            estimatedTouchPointArray: estimatedTouches
+        )
+        subject.updateLastEstimationUpdateIndexAtCompletionForTouchCompletion()
+
+        actualTouches
+            .sorted(by: { $0.timestamp < $1.timestamp })
+            .forEach { value in
+            subject.appendActualValueWithEstimatedValue(value)
+        }
+
+        /// Replacement is complete if the last `estimationUpdateIndex` in `actualTouchPointArray` matches `lastEstimationUpdateIndexAtCompletion`
+        if subject.hasActualValueReplacementCompleted {
+            /// Since `.ended` event is not sent from the Apple Pencil,
+            /// the last element of `estimatedTouchPointArray` is added to the end of `actualTouchPointArray` to finalize the process
+            subject.appendLastEstimatedTouchPointToActualTouchPointArray()
+        }
+
+        /// Verifies that the estimated value is used for `UITouch.Phase` and the actual value is used for `force`
+        XCTAssertEqual(subject.actualTouchPointArray[0].phase, estimatedTouches[0].phase)
+        XCTAssertEqual(subject.actualTouchPointArray[0].force, actualTouches[0].force)
+
+        XCTAssertEqual(subject.actualTouchPointArray[1].phase, estimatedTouches[1].phase)
+        XCTAssertEqual(subject.actualTouchPointArray[1].force, actualTouches[1].force)
+
+        XCTAssertEqual(subject.actualTouchPointArray[2].phase, estimatedTouches[2].phase)
+        XCTAssertEqual(subject.actualTouchPointArray[2].force, actualTouches[2].force)
+
+        /// Confirms that the last element of `estimatedTouchPointArray` is added to the end of `actualTouchPointArray` at `.ended`
+        XCTAssertEqual(subject.actualTouchPointArray[3].phase, estimatedTouches[3].phase)
+        XCTAssertEqual(subject.actualTouchPointArray[3].force, estimatedTouches[3].force)
+    }
+
+    /// Confirms that on `.ended`, `lastEstimationUpdateIndexAtCompletion` contains the `estimationUpdateIndex` from the second-to-last element of `estimatedTouchPointArray`
+    func testUpdateLastEstimationUpdateIndexAtTouchEnded() {
+        let subject = CanvasPencilScreenTouchPoints()
+
+        /// When the phase is not `.ended`, `lastEstimationUpdateIndexAtCompletion` will be `nil`
+        subject.appendEstimatedValue(.generate(phase: .began, estimationUpdateIndex: 0))
+        XCTAssertNil(subject.lastEstimationUpdateIndexAtCompletion)
+
+        subject.appendEstimatedValue(.generate(phase: .moved, estimationUpdateIndex: 1))
+        XCTAssertNil(subject.lastEstimationUpdateIndexAtCompletion)
+
+        subject.appendEstimatedValue(.generate(phase: .moved, estimationUpdateIndex: 2))
+        XCTAssertNil(subject.lastEstimationUpdateIndexAtCompletion)
+
+        /// When the `phase` is `.ended`, `lastEstimationUpdateIndexAtCompletion` will be `estimationUpdateIndex` of the element before the last element in `estimatedTouchPointArray`
+        subject.appendEstimatedValue(.generate(phase: .ended, estimationUpdateIndex: nil))
+        XCTAssertEqual(subject.lastEstimationUpdateIndexAtCompletion, 2)
+    }
+
+    /// Confirms that on `.cancelled`, `lastEstimationUpdateIndexAtCompletion` contains the `estimationUpdateIndex` from the second-to-last element of `estimatedTouchPointArray`
+    func testUpdateLastEstimationUpdateIndexAtTouchCancelled() {
+        let subject = CanvasPencilScreenTouchPoints()
+
+        /// When the phase is not `.ended`, `lastEstimationUpdateIndexAtCompletion` will be `nil`
+        subject.appendEstimatedValue(.generate(phase: .began, estimationUpdateIndex: 0))
+        XCTAssertNil(subject.lastEstimationUpdateIndexAtCompletion)
+
+        subject.appendEstimatedValue(.generate(phase: .moved, estimationUpdateIndex: 1))
+        XCTAssertNil(subject.lastEstimationUpdateIndexAtCompletion)
+
+        subject.appendEstimatedValue(.generate(phase: .moved, estimationUpdateIndex: 2))
+        XCTAssertNil(subject.lastEstimationUpdateIndexAtCompletion)
+
+        /// When the `phase` is `.cancelled`, `lastEstimationUpdateIndexAtCompletion` will be `estimationUpdateIndex` of the element before the last element in `estimatedTouchPointArray`
+        subject.appendEstimatedValue(.generate(phase: .cancelled, estimationUpdateIndex: nil))
+        XCTAssertEqual(subject.lastEstimationUpdateIndexAtCompletion, 2)
+    }
+
+}


### PR DESCRIPTION
The iPad and Apple Pencil are separate devices, and data is sent from the Apple Pencil to the iPad via Bluetooth. In UITouch, estimated values are returned first, and after an app receives the data, the actual values are returned.

https://developer.apple.com/documentation/uikit/apple_pencil_interactions/handling_input_from_apple_pencil/
This app had been using the estimated values, but since accurate force values cannot be obtained from the estimated values, the app has been updated in this PR to use the actual values.

