### PR TITLE
Set a default undo count to avoid out-of-memory issues

### DIFF
--- a/CanvasView/Sources/CanvasView/CanvasViewModel.swift
+++ b/CanvasView/Sources/CanvasView/CanvasViewModel.swift
@@ -110,6 +110,9 @@ public final class CanvasViewModel {
         self.drawingRenderers = drawingRenderers
         self.drawingRenderer = self.drawingRenderers[0]
 
+        // Set the undo count
+        self.textureLayers.setLevelsOfUndo(undoCount: configuration.undoCount)
+
         self.bindData()
 
         let environmentConfiguration = configuration.environmentConfiguration
@@ -618,13 +621,12 @@ extension CanvasViewModel {
                 }
             }
         }
-/*
+
         Task {
             try await textureLayers.pushUndoDrawingObjectToUndoStack(
                 texture: selectedLayerTexture
             )
         }
-*/
     }
 
     /// Called when the display texture size changes, such as when the device orientation changes

--- a/CanvasView/Sources/CanvasView/Configuration/CanvasConfiguration.swift
+++ b/CanvasView/Sources/CanvasView/Configuration/CanvasConfiguration.swift
@@ -13,18 +13,22 @@ import UIKit
     /// File extension used when saving a file
     public let fileSuffix: String
 
+    public let undoCount: Int
+
     public let projectConfiguration: ProjectConfiguration
     public let environmentConfiguration: EnvironmentConfiguration
 
     public init(
         textureSize: CGSize? = nil,
         fileSuffix: String = "",
+        undoCount: Int = 24,
         projectConfiguration: ProjectConfiguration = .init(),
         environmentConfiguration: EnvironmentConfiguration = .init()
     ) {
         // The screen size is used when the value is nil
         self.textureSize = textureSize ?? CanvasView.screenSize
         self.fileSuffix = CanvasConfiguration.sanitizedFileExtension(fileSuffix)
+        self.undoCount = undoCount
         self.projectConfiguration = projectConfiguration
         self.environmentConfiguration = environmentConfiguration
     }

--- a/CanvasView/Sources/CanvasView/Domain/Undo/UndoTextureLayers.swift
+++ b/CanvasView/Sources/CanvasView/Domain/Undo/UndoTextureLayers.swift
@@ -49,19 +49,14 @@ public final class UndoTextureLayers: ObservableObject {
         self.textureLayers = textureLayers
         self.renderer = renderer
         self.inMemoryRepository = inMemoryRepository
-    }
 
-    public func setupUndoManager(
-        undoCount: Int = 24
-    ) {
-        self.undoManager.levelsOfUndo = undoCount
+        // Set an initial value to prevent out-of-memory errors when no limit is applied
+        self.undoManager.levelsOfUndo = 8
         self.undoManager.groupsByEvent = false
     }
 
-    public func setUndoTextureRepository(
-        repository: UndoTextureInMemoryRepository
-    ) {
-        self.inMemoryRepository = repository
+    public func setLevelsOfUndo(undoCount: Int) {
+        self.undoManager.levelsOfUndo = undoCount
     }
 
     public func initializeUndoTextures(

--- a/HandDrawingSwiftMetal/HandDrawingContentView.xib
+++ b/HandDrawingSwiftMetal/HandDrawingContentView.xib
@@ -90,7 +90,7 @@
                         <constraint firstAttribute="width" constant="256" id="eVt-lc-xIh"/>
                     </constraints>
                 </slider>
-                <stackView hidden="YES" opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="w1G-k3-kW5" userLabel="UndoStackView">
+                <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="w1G-k3-kW5" userLabel="UndoStackView">
                     <rect key="frame" x="289" y="745" width="96" height="34.333333333333371"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="999" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="999" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Ib-t7-xwq">


### PR DESCRIPTION
Because no undo limit was defined, textures kept increasing